### PR TITLE
Use core lance install

### DIFF
--- a/smoosense-py/smoosense/utils/duckdb_connections.py
+++ b/smoosense-py/smoosense/utils/duckdb_connections.py
@@ -22,7 +22,7 @@ def duckdb_connection_default() -> DuckdbConnectionMaker:
         # Now install and load the extension
         con.execute("INSTALL httpfs")
         con.execute("LOAD httpfs")
-        con.execute("INSTALL lance FROM community")
+        con.execute("INSTALL lance")
         con.execute("LOAD lance")
         return con
 
@@ -58,7 +58,7 @@ def duckdb_connection_using_s3(
         # Now install and load the extension
         con.execute("INSTALL httpfs")
         con.execute("LOAD httpfs")
-        con.execute("INSTALL lance FROM community")
+        con.execute("INSTALL lance")
         con.execute("LOAD lance")
         # Configure DuckDB S3 settings
         con.execute(f"SET s3_region='{region}'")


### PR DESCRIPTION
This switches DuckDB extension setup from `INSTALL lance FROM community` to `INSTALL lance` in the Python connection helpers.
It aligns the repo with the core Lance extension packaging change tracked in https://github.com/lance-format/lance-duckdb/issues/180.
