### PR TITLE
PDF preview with data URLs

### DIFF
--- a/smoosense-gui/src/lib/utils/cellRenderers/HuggingFaceMediaCellRenderer.tsx
+++ b/smoosense-gui/src/lib/utils/cellRenderers/HuggingFaceMediaCellRenderer.tsx
@@ -6,6 +6,7 @@ import { getFileType, FileType } from '../fileTypes'
 import { toHuggingFaceDataUrl, getHuggingFaceMediaPath } from '../huggingFaceMediaUtils'
 import { AudioCellContent } from './AudioCellRenderer'
 import { ImageCellContent } from './ImageCellRenderer'
+import { PdfCellContent } from './PdfCellRenderer'
 import { useAppSelector } from '@/lib/hooks'
 
 interface HuggingFaceMediaCellRendererProps {
@@ -58,6 +59,10 @@ const HuggingFaceMediaCellRenderer = memo(function HuggingFaceMediaCellRenderer(
         alt={path}
       />
     )
+  }
+
+  if (fileType === FileType.Pdf) {
+    return <PdfCellContent pdfUrl={dataUrl} copyValue={path} />
   }
 
   if (fileType === FileType.Video) {

--- a/smoosense-gui/src/lib/utils/cellRenderers/PdfCellRenderer.tsx
+++ b/smoosense-gui/src/lib/utils/cellRenderers/PdfCellRenderer.tsx
@@ -7,19 +7,25 @@ import { mayResolveUrl } from '@/lib/utils/mediaUrlUtils'
 import { pathBasename } from "@/lib/utils/pathUtils"
 import { useAppSelector } from '@/lib/hooks'
 
-interface PdfCellRendererProps {
-  value: unknown
+interface PdfCellContentProps {
+  /** URL that goes into the iframe — may be a regular URL or a data: URL. */
+  pdfUrl: string
+  /** User-friendly identifier shown in header and copied on click (e.g. original path or filename). */
+  copyValue: string
+  /** URL used for external open; defaults to copyValue when omitted. */
+  openUrl?: string
 }
 
-const PdfCellRenderer = memo(function PdfCellRenderer({ value }: PdfCellRendererProps) {
-  const tablePath = useAppSelector((state) => state.ui.tablePath)
-  const baseUrl = useAppSelector((state) => state.ui.baseUrl)
-  const originalUrl = String(value).trim()
-
-  const resolvedUrl = mayResolveUrl({ value, tablePath, baseUrl })
-
-  // Extract filename from URL
-  const filename = pathBasename(originalUrl)
+/**
+ * Shared PDF cell content that renders a FileText-icon cell and an iframe popover.
+ * Accepts both regular URLs and data: URLs (for inline BLOB bytes).
+ */
+export const PdfCellContent = memo(function PdfCellContent({
+  pdfUrl,
+  copyValue,
+  openUrl,
+}: PdfCellContentProps) {
+  const filename = pathBasename(copyValue)
 
   const cellContent = (
     <div className="flex items-center gap-2 px-2 py-1">
@@ -30,7 +36,7 @@ const PdfCellRenderer = memo(function PdfCellRenderer({ value }: PdfCellRenderer
 
   const popoverContent = (
     <iframe
-      src={resolvedUrl}
+      src={pdfUrl}
       className="w-full h-full border-0"
       title="PDF Preview"
     />
@@ -40,11 +46,24 @@ const PdfCellRenderer = memo(function PdfCellRenderer({ value }: PdfCellRenderer
     <CellPopover
       cellContent={cellContent}
       popoverContent={popoverContent}
-      url={resolvedUrl}
-      copyValue={originalUrl}
+      url={openUrl ?? copyValue}
+      copyValue={copyValue}
       popoverClassName="w-[600px] h-[500px]"
     />
   )
+})
+
+interface PdfCellRendererProps {
+  value: unknown
+}
+
+const PdfCellRenderer = memo(function PdfCellRenderer({ value }: PdfCellRendererProps) {
+  const tablePath = useAppSelector((state) => state.ui.tablePath)
+  const baseUrl = useAppSelector((state) => state.ui.baseUrl)
+  const originalUrl = String(value).trim()
+  const resolvedUrl = mayResolveUrl({ value, tablePath, baseUrl })
+
+  return <PdfCellContent pdfUrl={resolvedUrl} copyValue={originalUrl} openUrl={resolvedUrl} />
 })
 
 export default PdfCellRenderer


### PR DESCRIPTION
## Add PDF preview for raw PDF bytes in parquet columns

This PR extends functionality of commit [`32d89d2`](https://github.com/SmooSenseAI/smoosense/commit/32d89d20e34d408b39f3a2781d6fffc81046535a) which supports image, audio and video preview from raw bytes.

 
The backend already detects `%PDF` magic bytes in BLOB cells and emits `{bytes: "data:application/pdf;base64,...", path: "detected.pdf"}`, and URL-based PDF columns already get `PdfCellRenderer`. But BLOB columns holding PDFs were falling through to the plain-text fallback at `HuggingFaceMediaCellRenderer.tsx:91-95`, so users just saw `detected.pdf` in muted text with no preview.

Example screenshot of the pdf preview:
<img width="638" height="501" alt="image" src="https://github.com/user-attachments/assets/1cc55e55-8ca0-4d39-9315-62c928d438ea" />

