### PR TITLE
Let resource limits (threads + memory) be overridable

### DIFF
--- a/smoosense-py/smoosense/utils/duckdb_connections.py
+++ b/smoosense-py/smoosense/utils/duckdb_connections.py
@@ -16,9 +16,17 @@ DuckdbConnectionMaker = Callable[[], DuckDBPyConnection]
 
 @validate_call()
 def duckdb_connection_default() -> DuckdbConnectionMaker:
+    # Optional caps via env vars; if unset, DuckDB picks defaults from the cgroup / nproc.
+    memory_limit = os.getenv("SMOOSENSE_DUCKDB_MEMORY_LIMIT")
+    threads = os.getenv("SMOOSENSE_DUCKDB_THREADS")
+
     def maker() -> DuckDBPyConnection:
         con = duckdb.connect()
 
+        if memory_limit:
+            con.execute(f"SET memory_limit='{memory_limit}'")
+        if threads:
+            con.execute(f"SET threads={threads}")
         # Now install and load the extension
         con.execute("INSTALL httpfs")
         con.execute("LOAD httpfs")
@@ -32,7 +40,6 @@ def duckdb_connection_default() -> DuckdbConnectionMaker:
 @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
 def duckdb_connection_using_s3(
     s3_client: BaseClient | None = None,
-    memory_limit: str = "3GB",
 ) -> DuckdbConnectionMaker:
     if s3_client is None:
         s3_client = boto3.client("s3")
@@ -62,7 +69,6 @@ def duckdb_connection_using_s3(
         # Set home_directory and temp_directory before httpfs auto-installs
         con.execute(f"SET home_directory='{home_directory}'")
         con.execute(f"SET temp_directory='{temp_directory}'")
-        con.execute(f"SET memory_limit='{memory_limit}'")
 
         # Now install and load the extension
         con.execute("INSTALL httpfs")


### PR DESCRIPTION
Currently, it's not possible to override or set memory or thread limits per DuckDB connection. For S3 queries, it's apparently hardcoded to S3 through a `memory_limit` parameter which isn't exposed anywhere (AFAIS).

Since the resource limits anyways should have higher relevance when `smoosense` is used in a hosted/server-side context, I decided to let this be configurable with env-vars instead, and also for *all* connection types, not just S3 ones.